### PR TITLE
Support Polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This preset includes the following plugins.
 - [@babel/plugin-transform-dotall-regex](https://babeljs.io/docs/en/babel-plugin-transform-dotall-regex)
 - [@babel/plugin-proposal-unicode-property-regex](https://babeljs.io/docs/en/babel-plugin-proposal-unicode-property-regex)
 
+### Polyfill
+
+- [@babel/plugin-transform-runtime](https://babeljs.io/docs/en/babel-plugin-transform-runtime)
+  - Using [core-js](https://github.com/zloirock/core-js) version 3
+
 ## Installation
 
 Using npm:

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,7 +213,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
       "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.8.3"
       }
@@ -769,6 +768,17 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
@@ -832,6 +842,12 @@
         "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.13.3",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
@@ -903,37 +919,21 @@
         "invariant": "^2.2.2",
         "levenary": "^1.1.0",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
+      "integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
-          "integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-explode-assignable-expression": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/helper-explode-assignable-expression": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
-          "integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
-          "dev": true,
-          "requires": {
-            "@babel/traverse": "^7.8.3",
-            "@babel/types": "^7.8.3"
-          }
-        },
-        "@babel/plugin-transform-exponentiation-operator": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
-          "integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
-            "@babel/helper-plugin-utils": "^7.8.3"
-          }
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -1743,14 +1743,14 @@
       }
     },
     "browserslist": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
-      "integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
+      "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001017",
-        "electron-to-chromium": "^1.3.322",
-        "node-releases": "^1.1.44"
+        "caniuse-lite": "^1.0.30001022",
+        "electron-to-chromium": "^1.3.338",
+        "node-releases": "^1.1.46"
       }
     },
     "bser": {
@@ -1798,9 +1798,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001020",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
-      "integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
+      "version": "1.0.30001023",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+      "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
       "dev": true
     },
     "capture-exit": {
@@ -1981,12 +1981,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true
-    },
     "core-js-compat": {
       "version": "3.6.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
@@ -2004,6 +1998,11 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2195,9 +2194,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.333",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.333.tgz",
-      "integrity": "sha512-7MJfCpa/tmhqYy2lZ1NEbkSxH7q3KiZiepiSs2ayTPAweAjdzGXotij+7OKPPb3OwJD2ZuBKPrA2HIuuSi6ahw==",
+      "version": "1.3.340",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
+      "integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
       "dev": true
     },
     "emoji-regex": {
@@ -4894,9 +4893,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.45",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
-      "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
+      "version": "1.1.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+      "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -5175,8 +5174,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "3.0.0",
@@ -5558,7 +5556,6 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
       "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -5688,8 +5685,7 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
     "@babel/plugin-transform-literals": "^7.8.3",
     "@babel/plugin-transform-object-super": "^7.8.3",
     "@babel/plugin-transform-parameters": "^7.8.3",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/plugin-transform-shorthand-properties": "^7.8.3",
     "@babel/plugin-transform-spread": "^7.8.3",
     "@babel/plugin-transform-template-literals": "^7.8.3",
     "@babel/plugin-transform-unicode-regex": "^7.8.3",
+    "@babel/runtime-corejs3": "^7.8.3",
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 "use strict";
 import { declare } from "@babel/helper-plugin-utils";
 
- // ES3
+// ES3
 import transformEs3MemberExpressionLiterals from "babel-plugin-transform-es3-member-expression-literals";
 import transformEs3PropertyLiterals from "babel-plugin-transform-es3-property-literals";
 // ES2015
@@ -27,6 +27,23 @@ import transformExponentiationOperator from "@babel/plugin-transform-exponentiat
 import proposalObjectRestSpread from "@babel/plugin-proposal-object-rest-spread";
 import transformDotallRegex from "@babel/plugin-transform-dotall-regex";
 import proposalUnicodePropertyRegex from "@babel/plugin-proposal-unicode-property-regex";
+// Polyfill
+import transformRuntime from "@babel/plugin-transform-runtime";
+
+const transformRuntimeCoreJsWraper = (0, declare)((api, options, dirname) => {
+  const corejsVersion = 3;
+  return transformRuntime(
+    api,
+    Object.assign(
+      {
+        corejs: corejsVersion,
+        version: "7.8.3"
+      },
+      options || {}
+    ),
+    dirname
+  );
+});
 
 export default declare(api => {
   api.assertVersion(7);
@@ -57,7 +74,9 @@ export default declare(api => {
       // ES2018
       proposalObjectRestSpread,
       transformDotallRegex,
-      proposalUnicodePropertyRegex
+      proposalUnicodePropertyRegex,
+      // Polyfill
+      transformRuntimeCoreJsWraper
     ]
   };
 });

--- a/test/fixtures/gas/polyfill/input.js
+++ b/test/fixtures/gas/polyfill/input.js
@@ -1,0 +1,3 @@
+[].includes(2);
+Symbol.for("bar");
+Symbol("bar");

--- a/test/fixtures/gas/polyfill/output.js
+++ b/test/fixtures/gas/polyfill/output.js
@@ -1,0 +1,13 @@
+var _Symbol = require("@babel/runtime-corejs3/core-js-stable/symbol");
+
+var _Symbol$for = require("@babel/runtime-corejs3/core-js-stable/symbol/for");
+
+var _includesInstanceProperty = require("@babel/runtime-corejs3/core-js-stable/instance/includes");
+
+var _context;
+
+_includesInstanceProperty(_context = []).call(_context, 2);
+
+_Symbol$for("bar");
+
+_Symbol("bar");


### PR DESCRIPTION
Babel's transform plugin alone does not support GAS perfectly, so it is supported by supporting polyfill.
It may solve the problem of https://github.com/kenchan0130/babel-preset-google-apps-script/issues/97, but I can't guarantee that it works properly, so I will be releasing it to see how it works.